### PR TITLE
Open service package in binary mode when uploading

### DIFF
--- a/bin/waz
+++ b/bin/waz
@@ -475,7 +475,7 @@ command 'deploy' do |c|
 
     name = File.basename(args[2]).gsub(' ', '') + Time.new.utc.strftime('%Y-%m-%d%H:%M:%S')
     blob = nil
-    open(args[2]) do |f|
+    open(args[2], 'rb') do |f|
       blob = container.upload(URI::escape(name), f, 'application/octet-stream')
     end
 


### PR DESCRIPTION
Fixes #2

This should work on Linux, too: http://stackoverflow.com/questions/8929610/automatically-open-a-file-as-binary-with-ruby
